### PR TITLE
Feature/issue 1 reactive support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ addons:
       secure: "G4fIIoaWBqiBCmO72ZLtv6P1wDQRANVO9KMxGlhTW9RuvA194iklaEyHqO99ah0bspmR5LKyAdLjxDypUl0cYNDHlrK8aYPkYogJZTkyjr8oVFrMBfmm3GHcxsb8IaPgms8zBIxQ+AH2CaBWKoK40TNgvuwPe3dq966Jq7pHnHQnPJzvO74LM+tSrRkwxiuZ1gky040FepCa2m/E+8jPjWuFEFyiddbhFgqA2+UPANxf8ug/A7gS9uGfB3OBUXF/3otnalD1Q97yQUkRqjHOHwwYZRGMR6RQP/TbaP1Bf7V1Q/3Er8jwj6ue639JNdEwIV8Cr8+doWCyxrgLrac+qEupmEgq63MutoLpj+bWmULBySqYXUyGTj4nPX1l3Doe+Xm+qtsfZa9uhrAsc98gidcTkwdGX3fht9ITG6kpNB5GDh2TP1J4/kK5aNb15GjJrzyX4Avj0CvBSvxw5jo2cNVWVsN1xnZc8m9SyPEp0wGpUigZu4HLW+pjmW1FqXL2YiWF+yPyyohkZI4oxwxJI+pRLVYCDEXDZuFnasKH03uR4DpRfniwb25N+iSv8r97V/ntUapTSaFVMOk4mBnfJcbIZmTc/UaanvLwCMpQEBT/HlsAC+LerCzvwhR/2SflZbF6jHZflZVZxTLehk5G0pZPmMRrtivsH+Be0NTMQPA="
 script:
   - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+
+# access full scm history
+# https://docs.travis-ci.com/user/sonarcloud/#accessing-full-scm-history
+git:
+  depth: false

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<name>Spring Security LTPA2</name>
 	<description>Support user pre-authentication using IBM Lightweight Third Party Authentication (LTPA) v2. LTPA2 tokens can be created as well.</description>
 	<url>http://www.sephiroth-j.de/java/spring-security-ltpa2/</url>
-	<version>0.2.4-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<inceptionYear>2018</inceptionYear>
 	<issueManagement>
 		<system>GitHub Issues</system>
@@ -29,9 +29,11 @@
 		<maven.compiler.source>${project.java.version}</maven.compiler.source>
 		<maven.compiler.target>${project.java.version}</maven.compiler.target>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-		<lombok.version>[1.16.18,)</lombok.version>
-		<spring.security.version>[4.2.4.RELEASE,)</spring.security.version>
-		<junit.jupiter.version>5.4.2</junit.jupiter.version>
+		<lombok.version>[1.18.10,)</lombok.version>
+		<spring.security.version>[5.1.0.RELEASE,)</spring.security.version>
+		<junit.jupiter.version>5.5.2</junit.jupiter.version>
+		<reactor.version>[3.2.0.RELEASE,)</reactor.version>
+		<jacoco.version>0.8.5</jacoco.version>
 	</properties>
 	
 	<developers>
@@ -49,12 +51,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<trimStackTrace>false</trimStackTrace>
 				</configuration>
@@ -62,7 +64,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.0</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -102,7 +104,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -127,7 +129,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.7.1</version>
+				<version>3.8.2</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.asciidoctor</groupId>
@@ -139,7 +141,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.3</version>
+				<version>${jacoco.version}</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>
@@ -160,12 +162,12 @@
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-ftp</artifactId>
-				<version>3.3.2</version>
+				<version>3.3.4</version>
 			</extension>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-webdav-jackrabbit</artifactId>
-				<version>3.3.2</version>
+				<version>3.3.4</version>
 			</extension>
 		</extensions>
 	</build>
@@ -196,7 +198,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -208,7 +210,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.3</version>
+				<version>${jacoco.version}</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -225,31 +227,33 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
 			<version>${spring.security.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
 			<version>${spring.security.version}</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
 			<version>${spring.security.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<version>${reactor.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>[3.1.0,)</version>
+			<version>[4.0.1,)</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.26</version>
-			<optional>true</optional>
+			<version>[1.7.30,1.7.99)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -266,19 +270,13 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>5.1.6.RELEASE</version>
+			<version>${spring.security.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit.jupiter.version}</version>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<version>${reactor.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -290,7 +288,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>[2.6.0,)</version>
+			<version>[3.14.0,)</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -302,7 +300,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.27.0</version>
+			<version>[3.2.4,)</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthConverter.java
+++ b/src/main/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthConverter.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019 Sephiroth.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.sephirothj.spring.security.ltpa2.reactive;
+
+import de.sephirothj.spring.security.ltpa2.Ltpa2Token;
+import de.sephirothj.spring.security.ltpa2.Ltpa2Utils;
+import java.security.PublicKey;
+import javax.crypto.SecretKey;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SynchronousSink;
+
+/**
+ * Strategy for converting a {@link ServerWebExchange} to an {@link Authentication} based on LTPA2 tokens. The final authentication will be done by a {@link Ltpa2AuthManager}. The token is expected to be given in the header {@link #headerName} with an {@link #headerValueIdentifier optional prefix}. If the header is empty or not found the token will be searched in the cookie named {@link #cookieName}.
+ *
+ * @author Sephiroth
+ */
+@Slf4j
+public class Ltpa2AuthConverter implements ServerAuthenticationConverter, InitializingBean
+{
+	/**
+	 * <p>
+	 * the name of the cookie expected to contain the LTPA2 token</p>
+	 * <p>
+	 * default: {@code "LtpaToken2"}</p>
+	 */
+	@Setter
+	@NonNull
+	private String cookieName = "LtpaToken2";
+
+	/**
+	 * <p>
+	 * the name of header expected to contain the LTPA2 token</p>
+	 * <p>
+	 * default: {@value HttpHeaders#AUTHORIZATION}</p>
+	 */
+	@Setter
+	@NonNull
+	private String headerName = HttpHeaders.AUTHORIZATION;
+
+	/**
+	 * <p>
+	 * the prefix in {@link #headername the header} preceding the LTPA2 token</p>
+	 * <p>
+	 * default: {@code cookieName + " "}</p>
+	 *
+	 * @see #cookieName
+	 */
+	@Setter
+	@NonNull
+	private String headerValueIdentifier = cookieName + " ";
+
+	/**
+	 * the public key from the identity provider that sends the LTPA2-tokens. required for signature validation.
+	 */
+	@Setter
+	@NonNull
+	private PublicKey signerKey;
+
+	/**
+	 * the shared secret key that is used to encrypt LTPA2 tokens
+	 */
+	@Setter
+	@NonNull
+	private SecretKey sharedKey;
+
+	/**
+	 * allow expired tokens
+	 * <p>
+	 * <b>Do not use in prodcution mode, only for testing!</b></p>
+	 */
+	@Setter
+	private boolean allowExpiredToken = false;
+
+	@Override
+	public void afterPropertiesSet()
+	{
+		Assert.hasText(cookieName, "A cookieName is required");
+		Assert.hasText(headerName, "A headerName is required");
+		Assert.notNull(headerValueIdentifier, "The headerValueIdentifier must not be null");
+		Assert.notNull(signerKey, "A signerKey is required");
+		Assert.notNull(sharedKey, "A sharedKey is required");
+		if (allowExpiredToken)
+		{
+			log.warn("Expired LTPA2 tokens are allowed, this should only be used for testing!");
+		}
+	}
+
+	private void checkForExpiredToken(final String ltpaToken, final SynchronousSink<String> sink)
+	{
+		try
+		{
+			if (!Ltpa2Utils.isTokenExpired(ltpaToken) || allowExpiredToken)
+			{
+				sink.next(ltpaToken);
+			}
+			else
+			{
+				throw new InsufficientAuthenticationException("token expired");
+			}
+		}
+		catch (AuthenticationException e)
+		{
+			// do not produce mono error, just log and produce empty mono as by contract of ServerAuthenticationConverter
+			log.warn(e.getLocalizedMessage());
+		}
+	}
+
+	private void checkTokenSignature(final String ltpaToken, final SynchronousSink<String> sink)
+	{
+		try
+		{
+			if (Ltpa2Utils.isSignatureValid(ltpaToken, signerKey))
+			{
+				sink.next(ltpaToken);
+			}
+			else
+			{
+				throw new InsufficientAuthenticationException("token signature invalid");
+			}
+		}
+		catch (AuthenticationException e)
+		{
+			// do not produce mono error, just log and produce empty mono as by contract of ServerAuthenticationConverter
+			log.warn(e.getLocalizedMessage());
+		}
+	}
+
+	/**
+	 * Extracts an LTAP2 token from the defined {@link #headerName header} or {@link #cookieName cookie} (as fallback), validates it and if it is, creates an {@link Authentication} instance with it
+	 *
+	 * @param exchange The {@link ServerWebExchange}
+	 * @return A {@link Mono} representing an {@link Authentication} with a valid {@link Ltpa2Token} as credentials or an empty Mono if the token was not found or is invalid
+	 */
+	@Override
+	public Mono<Authentication> convert(ServerWebExchange exchange)
+	{
+		final ServerHttpRequest request = exchange.getRequest();
+		return Mono.justOrEmpty(request.getHeaders().getFirst(headerName))
+			.filter(header -> !header.isEmpty() && header.startsWith(headerValueIdentifier))
+			.map(header -> header.substring(header.indexOf(headerValueIdentifier) + headerValueIdentifier.length()))
+			// try cookie as fallback
+			.switchIfEmpty(Mono.defer(() -> Mono.justOrEmpty(request.getCookies().getFirst(cookieName)).map(HttpCookie::getValue)))
+			.doOnNext(encryptedToken -> log.debug("raw LTPA2 token: {}", encryptedToken))
+			.map(encryptedToken -> Ltpa2Utils.decryptLtpa2Token(encryptedToken, sharedKey))
+			.onErrorResume(e ->
+			{
+				log.warn(e.getLocalizedMessage());
+				return Mono.empty();
+			})
+			.handle(this::checkForExpiredToken)
+			.handle(this::checkTokenSignature)
+			.map(Ltpa2Utils::makeInstance)
+			.map(token -> new PreAuthenticatedAuthenticationToken(token.getUser(), token));
+	}
+
+}

--- a/src/main/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthManager.java
+++ b/src/main/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthManager.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Sephiroth.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.sephirothj.spring.security.ltpa2.reactive;
+
+import de.sephirothj.spring.security.ltpa2.Ltpa2Token;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.security.authentication.AccountStatusException;
+import org.springframework.security.authentication.AccountStatusUserDetailsChecker;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsChecker;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SynchronousSink;
+
+/**
+ * Performs the final authentication of an {@link Authentication} instance previously created by {@link Ltpa2AuthConverter}.
+ *
+ * @author Sephiroth
+ */
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class Ltpa2AuthManager implements ReactiveAuthenticationManager
+{
+	/**
+	 * A ReactiveUserDetailsService required to lookup the user given in the provided Ltpa2Token
+	 */
+	@NonNull
+	private final ReactiveUserDetailsService userDetailsService;
+
+	/**
+	 * An optional UserDetailsChecker such as {@link AccountStatusUserDetailsChecker}. It should throw an {@link AccountStatusException} in case somethings is not right with the {@link UserDetails}.
+	 */
+	@Nullable
+	private UserDetailsChecker userDetailsChecker;
+
+	/**
+	 * Attempts to authenticate the provided {@link Authentication} with a {@link Ltpa2Token} as credentials
+	 *
+	 * @param authentication the {@link Authentication} to test
+	 * @return If authentication is successful an {@link Authentication} is returned. If authentication cannot be determined, an empty Mono is returned. If authentication fails, a Mono error is returned.
+	 */
+	@Override
+	public Mono<Authentication> authenticate(Authentication authentication)
+	{
+		return supports(authentication) ? Mono.just(authentication)
+			.map(Authentication::getName)
+			.flatMap(userDetailsService::findByUsername)
+			.switchIfEmpty(Mono.error(() -> new UsernameNotFoundException("User not found")))
+			.handle(this::checkUser)
+			.map(user -> new PreAuthenticatedAuthenticationToken(user, null, user.getAuthorities()))
+			: Mono.empty();
+	}
+
+	private void checkUser(final UserDetails user, final SynchronousSink<UserDetails> sink)
+	{
+		if (userDetailsChecker != null)
+		{
+			try
+			{
+				userDetailsChecker.check(user);
+				sink.next(user);
+			}
+			catch (AccountStatusException e)
+			{
+				sink.error(e);
+			}
+		}
+		else
+		{
+			sink.next(user);
+		}
+	}
+
+	private boolean supports(final Authentication authentication)
+	{
+		return PreAuthenticatedAuthenticationToken.class.isAssignableFrom(authentication.getClass())
+			&& Ltpa2Token.class.isAssignableFrom(authentication.getCredentials().getClass());
+	}
+}

--- a/src/site/asciidoc/usage.adoc
+++ b/src/site/asciidoc/usage.adoc
@@ -3,8 +3,8 @@
 This short example shows how to use the LTPA2 Security Module. This example uses Spring Boot.
 
 === Requirements
-- Spring Security 4.2+
-- Spring Boot 1.5+
+- Spring Security 5.1+
+- Spring Boot 2.1+
 
 === Integration
 ==== pom.xml
@@ -23,7 +23,7 @@ Add it as an dependency together with you Spring Security dependencies.
 		<dependency>
 			<groupId>de.sephiroth-j</groupId>
 			<artifactId>spring-security-ltpa2</artifactId>
-			<version>[0.1.0,)</version>
+			<version>[1.0.0,)</version>
 		</dependency>
 	</dependencies>
 
@@ -35,7 +35,7 @@ Add it as an dependency together with you Spring Security dependencies.
 	</repositories>
 --
 
-==== Web Security Configuration
+==== Security Configuration for Web Servlet
 Add the `Ltpa2Filter` using `Ltpa2Configurer`. It needs a `SecretKey` instance of the shared key that is used for the symmetric encryption and decryption of the LTPA2 token. In order to verify the provided token, it also needs the `PublicKey` from the identity provider (for example IBM Secure Gateway / DataPower) that sends the LTPA2 token.
 
 As the user is pre-authenticated, an instance of `UserDetailsService` is required to setup the security context and populate it with the granted roles for the authenticated user. In this example we will simply use `InMemoryAuthentication` with a hard-coded list of users and their roles.
@@ -107,6 +107,52 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter
 		manager.setUsernameMapper(new DefaultLdapUsernameToDnMapper("ou=user", "cn"));
 		manager.setGroupSearchBase("ou=groups");
 		return manager;
+	}
+}
+--
+
+==== Security Configuration for Web Reactive
+Add an `AuthenticationWebFilter` using `Ltpa2AuthManager` and the `Ltpa2AuthConverter`. The `Ltpa2AuthConverter` needs a `SecretKey` instance of the shared key that is used for the symmetric encryption of the LTPA2 token. In order to verify the provided token, it also needs the `PublicKey` from the identity provider (for example IBM Secure Gateway / DataPower) that sends the LTPA2 token.
+
+As the user is pre-authenticated, an instance of `ReactiveUserDetailsService` is required to setup the security context and populate it with the granted roles for the authenticated user. In this example we will simply use `MapReactiveUserDetailsService` with a hard-coded list of users and their roles.
+
+[source,java]
+--
+@Configuration
+@EnableWebFluxSecurity
+public class WebSecurityConfig
+{
+
+	@Bean
+	public SecurityWebFilterChain springSecurityFilterChain(final ServerHttpSecurity http, final ReactiveUserDetailsService userDetailsService, AuthenticationWebFilter ltpa2AuthenticationWebFilter)
+	{
+		http
+			.httpBasic().disable()
+			.authorizeExchange()
+			// all other require any authentication
+			.anyExchange().authenticated()
+			.and()
+			// apply ltpa2 authentication filter
+			.addFilterAt(ltpa2AuthenticationWebFilter, SecurityWebFiltersOrder.AUTHENTICATION);
+		return http.build();
+	}
+
+	@Bean
+	AuthenticationWebFilter x509AuthenticationWebFilter(ReactiveUserDetailsService userDetailsService) throws GeneralSecurityException
+	{
+		final Ltpa2AuthConverter converter = new Ltpa2AuthConverter();
+		converter.setSharedKey(sharedKey());
+		converter.setSignerKey(signerKey());
+
+		final AuthenticationWebFilter webfilter = new AuthenticationWebFilter(new Ltpa2AuthManager(userDetailsService));
+		webfilter.setServerAuthenticationConverter(converter);
+		return webfilter;
+	}
+
+	@Bean
+	public ReactiveUserDetailsService userDetailsService()
+	{
+		return new MapReactiveUserDetailsService(User.withUsername("user").password("password").roles("USER").build());
 	}
 }
 --

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -5,7 +5,7 @@
 	<skin>
 		<groupId>org.apache.maven.skins</groupId>
 		<artifactId>maven-fluido-skin</artifactId>
-		<version>1.7</version>
+		<version>1.8</version>
 	</skin>
 	<body>
 		<menu name="Overview">
@@ -16,7 +16,8 @@
 			<item name="Links" href="links.html" />
 		</menu>
 		<menu name="Examples">
-			<item name="Sample Project" href="https://github.com/sephiroth-j/spring-security-ltpa2-sample" />
+			<item name="Project for Web Servlet Stack" href="https://github.com/sephiroth-j/spring-security-ltpa2-sample" />
+			<item name="Project for Web Reactive Stack" href="https://github.com/sephiroth-j/spring-security-ltpa2-reactive-sample" />
 		</menu>
 		<menu ref="reports" />
 	</body>

--- a/src/test/java/de/sephirothj/spring/security/ltpa2/Constants.java
+++ b/src/test/java/de/sephirothj/spring/security/ltpa2/Constants.java
@@ -43,4 +43,9 @@ public class Constants
 	 * password that has been used for encypting of {@link #ENCRYPTED_PRIVATE_KEY} and {@link #ENCRYPTED_SHARED_KEY}
 	 */
 	public final String ENCRYPTION_PASSWORD = "test123";
+	
+	/**
+	 * base64-encoded ltpa2 token
+	 */
+	public final String TEST_TOKEN = "Wl3qcMXdvCZjScDwB18/5VYujKDYsptVWXwNVW2yKuZw6h5Kg4amiGDeQCh2xmtNVPgCkzyk66ZWrdY70+nQEe+gotHjJtrcoW/VnbbQAwrQE5GojqK+1RdjvnwmQ9QULqcYAItw4ggZ2JF3CRR5uZ3NSFgkZpzkcMbfuYSWipNXsqEUHKONUlrg0Oc6lNKqWknx87HoPKmTnkGD5gdecu1FJCKUXSk1tanAjN3RaEWY8woxMIJQEMw/yeOrA9Fe+1nWjGAR5ITgkm+whpXfzl3n3g7kWHaBJf8DUUlKRsww4oCe3+t85b1WqoTC6FZw2qovLwn3ioRm1eIBDPO+KQZD60Ps4f+QEOjFzkLQC2f6BlZKc8KMHhffRQRpBgOD6kYV/wGDRHuvkK5vMAeJtQ==";
 }

--- a/src/test/java/de/sephirothj/spring/security/ltpa2/Ltpa2FilterTest.java
+++ b/src/test/java/de/sephirothj/spring/security/ltpa2/Ltpa2FilterTest.java
@@ -17,11 +17,12 @@ package de.sephirothj.spring.security.ltpa2;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.PublicKey;
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -33,6 +34,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -42,6 +44,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.Base64Utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,7 +57,6 @@ import static org.mockito.Mockito.verify;
  */
 public class Ltpa2FilterTest
 {
-	private static final String TEST_TOKEN = "Wl3qcMXdvCZjScDwB18/5VYujKDYsptVWXwNVW2yKuZw6h5Kg4amiGDeQCh2xmtNVPgCkzyk66ZWrdY70+nQEe+gotHjJtrcoW/VnbbQAwrQE5GojqK+1RdjvnwmQ9QULqcYAItw4ggZ2JF3CRR5uZ3NSFgkZpzkcMbfuYSWipNXsqEUHKONUlrg0Oc6lNKqWknx87HoPKmTnkGD5gdecu1FJCKUXSk1tanAjN3RaEWY8woxMIJQEMw/yeOrA9Fe+1nWjGAR5ITgkm+whpXfzl3n3g7kWHaBJf8DUUlKRsww4oCe3+t85b1WqoTC6FZw2qovLwn3ioRm1eIBDPO+KQZD60Ps4f+QEOjFzkLQC2f6BlZKc8KMHhffRQRpBgOD6kYV/wGDRHuvkK5vMAeJtQ==";
 	
 	@Test
 	public void getTokenFromHeaderTestWithDefaultPrefix()
@@ -174,9 +176,9 @@ public class Ltpa2FilterTest
 		Ltpa2Filter uut = new Ltpa2Filter();
 		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
 
-		AuthenticationException expected = Assertions.assertThrows(AuthenticationException.class, () ->
+		AuthenticationException expected = Assertions.assertThrows(InsufficientAuthenticationException.class, () ->
 		{
-			ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", TEST_TOKEN);
+			ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", Constants.TEST_TOKEN);
 		});
 		assertThat(expected).hasMessage("token expired");
 	}
@@ -193,7 +195,7 @@ public class Ltpa2FilterTest
 		UserDetails mockUser = User.withUsername("test-user").roles("DEVELOPERS").password("dummy password").build();
 		given(mock.loadUserByUsername(anyString())).willReturn(mockUser);
 
-		UserDetails actual = ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", TEST_TOKEN);
+		UserDetails actual = ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", Constants.TEST_TOKEN);
 		assertThat(actual).isEqualTo(mockUser);
 	}
 
@@ -202,16 +204,22 @@ public class Ltpa2FilterTest
 	{
 		Ltpa2Filter uut = new Ltpa2Filter();
 		uut.setAllowExpiredToken(true);
-		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
-		KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-		KeyPair pair = keyGen.generateKeyPair();
-		uut.setSignerKey(pair.getPublic());
+		final SecretKey decryptSharedKey = LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD);
+		uut.setSharedKey(decryptSharedKey);
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		
+		String tokenWithInvalidSignature = "expire:1519043460000$u:user\\:LdapRegistry/CN=fae6d87c-c642-45a6-9f09-915c7fd8b08c,OU=user,DC=foo,DC=bar%1519043460000%ipDldknyTbaSZluHTW3I/Dhh9veyi+QHoX3s4MPxvvTc09COCGGbOQLxiGoIqdBxDrv55WChFNDD6uUtnt74gNX2KTRQpbwY5zSMbNHkUrh/6X+OOqbvcR3fAmIBkTAyBwkX3u6T2WEoEq9FxOYpvlhqvygoJYrjM6JuQeGhvBB=";
+		final Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+		final IvParameterSpec iv = new IvParameterSpec(decryptSharedKey.getEncoded());
+		c.init(Cipher.ENCRYPT_MODE, decryptSharedKey, iv);
+		final byte[] rawEncryptedToken = c.doFinal(tokenWithInvalidSignature.getBytes(StandardCharsets.UTF_8));
+		String encryptedToken = Base64Utils.encodeToString(rawEncryptedToken);
 
-		AuthenticationException expected = Assertions.assertThrows(AuthenticationException.class, () ->
+		AuthenticationException expected = Assertions.assertThrows(InsufficientAuthenticationException.class, () ->
 		{
-			ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", TEST_TOKEN);
+			ReflectionTestUtils.invokeMethod(uut, "validateLtpaTokenAndLoadUser", encryptedToken);
 		});
-		assertThat(expected).hasMessage("failed to verify token signature");
+		assertThat(expected).hasMessage("token signature invalid");
 	}
 
 	@Test
@@ -246,7 +254,7 @@ public class Ltpa2FilterTest
 	@Test
 	void doFilterInternalShouldSetAuthentication() throws ServletException, IOException, GeneralSecurityException
 	{
-		HttpServletRequest request = MockMvcRequestBuilders.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(TEST_TOKEN)).buildRequest(new MockServletContext());
+		HttpServletRequest request = MockMvcRequestBuilders.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(Constants.TEST_TOKEN)).buildRequest(new MockServletContext());
 		UserDetailsService userDetailsService = Mockito.mock(UserDetailsService.class);
 		UserDetails mockUser = User.withUsername("test-user").roles("DEVELOPERS").password("dummy password").build();
 		given(userDetailsService.loadUserByUsername(anyString())).willReturn(mockUser);
@@ -267,9 +275,9 @@ public class Ltpa2FilterTest
 	}
 
 	@Test
-	void doFilterInternalShouldCause401ForUnknownUsers() throws ServletException, IOException, GeneralSecurityException
+	void doFilterInternalShouldCause403ForUnknownUsers() throws ServletException, IOException, GeneralSecurityException
 	{
-		HttpServletRequest request = MockMvcRequestBuilders.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(TEST_TOKEN)).buildRequest(new MockServletContext());
+		HttpServletRequest request = MockMvcRequestBuilders.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(Constants.TEST_TOKEN)).buildRequest(new MockServletContext());
 		HttpServletResponse response = new MockHttpServletResponse();
 		UserDetailsService userDetailsService = Mockito.mock(UserDetailsService.class);
 		given(userDetailsService.loadUserByUsername(anyString())).willThrow(UsernameNotFoundException.class);
@@ -283,6 +291,6 @@ public class Ltpa2FilterTest
 
 		verify(userDetailsService).loadUserByUsername(anyString());
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
 	}
 }

--- a/src/test/java/de/sephirothj/spring/security/ltpa2/Ltpa2UtilsTest.java
+++ b/src/test/java/de/sephirothj/spring/security/ltpa2/Ltpa2UtilsTest.java
@@ -39,8 +39,7 @@ public class Ltpa2UtilsTest
 	private static String getTestToken() throws GeneralSecurityException
 	{
 		SecretKey secretKey = LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD);
-		String testToken = "Wl3qcMXdvCZjScDwB18/5VYujKDYsptVWXwNVW2yKuZw6h5Kg4amiGDeQCh2xmtNVPgCkzyk66ZWrdY70+nQEe+gotHjJtrcoW/VnbbQAwrQE5GojqK+1RdjvnwmQ9QULqcYAItw4ggZ2JF3CRR5uZ3NSFgkZpzkcMbfuYSWipNXsqEUHKONUlrg0Oc6lNKqWknx87HoPKmTnkGD5gdecu1FJCKUXSk1tanAjN3RaEWY8woxMIJQEMw/yeOrA9Fe+1nWjGAR5ITgkm+whpXfzl3n3g7kWHaBJf8DUUlKRsww4oCe3+t85b1WqoTC6FZw2qovLwn3ioRm1eIBDPO+KQZD60Ps4f+QEOjFzkLQC2f6BlZKc8KMHhffRQRpBgOD6kYV/wGDRHuvkK5vMAeJtQ==";
-		return Ltpa2Utils.decryptLtpa2Token(testToken, secretKey);
+		return Ltpa2Utils.decryptLtpa2Token(Constants.TEST_TOKEN, secretKey);
 	}
 
 	@Test

--- a/src/test/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthConverterTest.java
+++ b/src/test/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthConverterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2019 Sephiroth.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.sephirothj.spring.security.ltpa2.reactive;
+
+import de.sephirothj.spring.security.ltpa2.Constants;
+import de.sephirothj.spring.security.ltpa2.Ltpa2Token;
+import de.sephirothj.spring.security.ltpa2.LtpaKeyUtils;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.Base64Utils;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Sephiroth
+ */
+class Ltpa2AuthConverterTest
+{
+
+	@Test
+	void getTokenFromHeaderTestWithDefaultPrefix() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+		uut.afterPropertiesSet();
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void getTokenFromHeaderTestWithCustomPrefix() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+		String prefix = "my-prefix";
+		uut.setHeaderValueIdentifier(prefix);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, prefix.concat(Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void getTokenFromHeaderTestWithEmptyPrefix() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+		uut.setHeaderValueIdentifier("");
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, Constants.TEST_TOKEN);
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void getTokenFromHeaderTestWithCustomName() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+		String headerName = "my-header";
+		uut.setHeaderName(headerName);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(headerName, "LtpaToken2 ".concat(Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void getTokenFromCookieTestWithDefaultName() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").cookie(new HttpCookie("LtpaToken2", Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void getTokenFromCookieTestWithCustomName() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+		String cookieName = "my-cookie";
+		uut.setCookieName(cookieName);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").cookie(new HttpCookie(cookieName, Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.assertNext(this::verifyAuth)
+			.verifyComplete();
+	}
+
+	@Test
+	void expiredTokenShouldBeRejected() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(Constants.TEST_TOKEN));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.verifyComplete();
+	}
+
+	@Test
+	void invalidSignaturesShouldBeRejected() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		final SecretKey decryptSharedKey = LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD);
+		uut.setSharedKey(decryptSharedKey);
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+
+		String tokenWithInvalidSignature = "expire:1519043460000$u:user\\:LdapRegistry/CN=fae6d87c-c642-45a6-9f09-915c7fd8b08c,OU=user,DC=foo,DC=bar%1519043460000%ipDldknyTbaSZluHTW3I/Dhh9veyi+QHoX3s4MPxvvTc09COCGGbOQLxiGoIqdBxDrv55WChFNDD6uUtnt74gNX2KTRQpbwY5zSMbNHkUrh/6X+OOqbvcR3fAmIBkTAyBwkX3u6T2WEoEq9FxOYpvlhqvygoJYrjM6JuQeGhvBB=";
+		final Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+		final IvParameterSpec iv = new IvParameterSpec(decryptSharedKey.getEncoded());
+		c.init(Cipher.ENCRYPT_MODE, decryptSharedKey, iv);
+		final byte[] rawEncryptedToken = c.doFinal(tokenWithInvalidSignature.getBytes(StandardCharsets.UTF_8));
+		String encryptedToken = Base64Utils.encodeToString(rawEncryptedToken);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(encryptedToken));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.verifyComplete();
+	}
+
+	@Test
+	void invalidTokensShouldBeRejected() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		uut.setSharedKey(LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD));
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 asd");
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.verifyComplete();
+	}
+
+	@Test
+	void malformedTokensShouldBeRejected() throws GeneralSecurityException
+	{
+		Ltpa2AuthConverter uut = new Ltpa2AuthConverter();
+		final SecretKey decryptSharedKey = LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD);
+		uut.setSharedKey(decryptSharedKey);
+		uut.setSignerKey(LtpaKeyUtils.decodePublicKey(Constants.ENCODED_PUBLIC_KEY));
+		uut.setAllowExpiredToken(true);
+
+		String tokenWithMissingSignature = "expire:1519043460000$u:user\\:LdapRegistry/CN=fae6d87c-c642-45a6-9f09-915c7fd8b08c,OU=user,DC=foo,DC=bar%1519043460000";
+		final Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+		final IvParameterSpec iv = new IvParameterSpec(decryptSharedKey.getEncoded());
+		c.init(Cipher.ENCRYPT_MODE, decryptSharedKey, iv);
+		final byte[] rawEncryptedToken = c.doFinal(tokenWithMissingSignature.getBytes(StandardCharsets.UTF_8));
+		String encryptedToken = Base64Utils.encodeToString(rawEncryptedToken);
+
+		MockServerHttpRequest.BaseBuilder requestBuilder = MockServerHttpRequest.get("/").header(HttpHeaders.AUTHORIZATION, "LtpaToken2 ".concat(encryptedToken));
+		StepVerifier.create(uut.convert(MockServerWebExchange.from(requestBuilder.build())))
+			.verifyComplete();
+	}
+
+	private void verifyAuth(Authentication auth)
+	{
+		assertThat(auth.isAuthenticated()).isFalse();
+		assertThat(auth.getCredentials()).isInstanceOf(Ltpa2Token.class);
+		assertThat(auth.getPrincipal()).isEqualTo(auth.getName()).asString().isEqualTo("user:LdapRegistry/CN=fae6d87c-c642-45a6-9f09-915c7fd8b08c,OU=user,DC=foo,DC=bar");
+	}
+}

--- a/src/test/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthManagerTest.java
+++ b/src/test/java/de/sephirothj/spring/security/ltpa2/reactive/Ltpa2AuthManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Sephiroth.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.sephirothj.spring.security.ltpa2.reactive;
+
+import de.sephirothj.spring.security.ltpa2.Constants;
+import de.sephirothj.spring.security.ltpa2.Ltpa2Token;
+import de.sephirothj.spring.security.ltpa2.Ltpa2Utils;
+import de.sephirothj.spring.security.ltpa2.LtpaKeyUtils;
+import java.security.GeneralSecurityException;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.AccountStatusUserDetailsChecker;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ *
+ * @author Sephiroth
+ */
+public class Ltpa2AuthManagerTest
+{
+	private static Ltpa2Token getTestToken() throws GeneralSecurityException
+	{
+		SecretKey secretKey = LtpaKeyUtils.decryptSharedKey(Constants.ENCRYPTED_SHARED_KEY, Constants.ENCRYPTION_PASSWORD);
+		return Ltpa2Utils.makeInstance(Ltpa2Utils.decryptLtpa2Token(Constants.TEST_TOKEN, secretKey));
+	}
+
+	@Test
+	void authenticateTest() throws GeneralSecurityException, Exception
+	{
+		ReactiveUserDetailsService userDetailsService = Mockito.mock(ReactiveUserDetailsService.class);
+		final UserDetails mockUser = User.withUsername("test").password("password").roles("tester").build();
+		given(userDetailsService.findByUsername(anyString())).willReturn(Mono.just(mockUser));
+		Ltpa2AuthManager uut = new Ltpa2AuthManager(userDetailsService);
+		Ltpa2Token token = getTestToken();
+
+		StepVerifier.create(uut.authenticate(new PreAuthenticatedAuthenticationToken(token.getUser(), token)))
+			.assertNext(auth ->
+			{
+				assertThat(auth.isAuthenticated()).isTrue();
+				assertThat(auth.getCredentials()).isNull();
+				assertThat(auth.getPrincipal()).isEqualTo(mockUser);
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void authenticateTestWithUserChecker() throws GeneralSecurityException, Exception
+	{
+		ReactiveUserDetailsService userDetailsService = Mockito.mock(ReactiveUserDetailsService.class);
+		final UserDetails mockUser = User.withUsername("test").password("password").roles("tester").build();
+		given(userDetailsService.findByUsername(anyString())).willReturn(Mono.just(mockUser));
+		Ltpa2AuthManager uut = new Ltpa2AuthManager(userDetailsService, new AccountStatusUserDetailsChecker());
+		Ltpa2Token token = getTestToken();
+
+		StepVerifier.create(uut.authenticate(new PreAuthenticatedAuthenticationToken(token.getUser(), token)))
+			.assertNext(auth ->
+			{
+				assertThat(auth.isAuthenticated()).isTrue();
+				assertThat(auth.getCredentials()).isNull();
+				assertThat(auth.getPrincipal()).isEqualTo(mockUser);
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void authenticateTestWithUserCheckerAndLockedAccout() throws GeneralSecurityException, Exception
+	{
+		ReactiveUserDetailsService userDetailsService = Mockito.mock(ReactiveUserDetailsService.class);
+		final UserDetails mockUser = User.withUsername("test").password("password").roles("tester").accountLocked(true).build();
+		given(userDetailsService.findByUsername(anyString())).willReturn(Mono.just(mockUser));
+		Ltpa2AuthManager uut = new Ltpa2AuthManager(userDetailsService, new AccountStatusUserDetailsChecker());
+		Ltpa2Token token = getTestToken();
+
+		StepVerifier.create(uut.authenticate(new PreAuthenticatedAuthenticationToken(token.getUser(), token)))
+			.verifyError(LockedException.class);
+	}
+
+	@Test
+	void authenticateWithUnknownUserTest() throws GeneralSecurityException, Exception
+	{
+		ReactiveUserDetailsService userDetailsService = Mockito.mock(ReactiveUserDetailsService.class);
+		given(userDetailsService.findByUsername(anyString())).willReturn(Mono.empty());
+		Ltpa2AuthManager uut = new Ltpa2AuthManager(userDetailsService);
+		Ltpa2Token token = getTestToken();
+
+		StepVerifier.create(uut.authenticate(new PreAuthenticatedAuthenticationToken(token.getUser(), token)))
+			.verifyErrorSatisfies(t ->
+			{
+				assertThat(t).isInstanceOf(UsernameNotFoundException.class).hasMessage("User not found");
+			});
+	}
+
+	@Test
+	void authenticateWithUnsupportedAuthTest() throws GeneralSecurityException, Exception
+	{
+		ReactiveUserDetailsService userDetailsService = Mockito.mock(ReactiveUserDetailsService.class);
+		given(userDetailsService.findByUsername(anyString())).willReturn(Mono.empty());
+		Ltpa2AuthManager uut = new Ltpa2AuthManager(userDetailsService);
+
+		StepVerifier.create(uut.authenticate(new PreAuthenticatedAuthenticationToken("test", "test")))
+			.verifyComplete();
+	}
+}


### PR DESCRIPTION
- **breaking** Ltpa2Filter will return `FORBIDDEN` instead of `UNAUTHORIZED` when there was a problem with the token or the user was not found.
This corresponds more to the HTTP specification and matches the default behavior when no token was given at all.
- **new** Emit a warning when `allowExpiredToken` is enabled
- **new** **Support the Reactive Stack** with `Ltpa2AuthConverter` and `Ltpa2AuthManager`
check the README.md for the details

Fixes #1 