### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-project-info-reports-plugin from 3.5.0 to 3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.5.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>


### PR DESCRIPTION
Reverts sephiroth-j/spring-security-ltpa2-core#39 because of [build errors after merging](https://github.com/sephiroth-j/spring-security-ltpa2-core/actions/runs/9665485093)